### PR TITLE
PR for Configurable location and wrap

### DIFF
--- a/management/commands/makemessages.py
+++ b/management/commands/makemessages.py
@@ -17,10 +17,10 @@ class Command(BaseMakemessages):
         super(Command, self).add_arguments(parser)
 
         parser.add_argument('--yes-location', action='store_true', dest='yes_location',
-                            default=settings.ADD_LOCATION if hasattr(settings,'ADD_LOCATION') else False, 
+                            default=getattr(settings, 'ADD_LOCATION', False), 
                             help="Do write '#: filename:line' lines.")
         parser.add_argument('--yes-wrap', action='store_true', dest='yes_wrap',
-                            default=settings.DO_WRAP if hasattr(settings, 'DO_WRAP') else False, 
+                            default=getattr(settings, 'DO_WRAP', False), 
                             help="Do wrap long messages for 80 chars")
         parser.add_argument('apps', nargs='*', choices=settings.INSTALLED_APPS + [[],])
 

--- a/management/commands/makemessages.py
+++ b/management/commands/makemessages.py
@@ -17,9 +17,11 @@ class Command(BaseMakemessages):
         super(Command, self).add_arguments(parser)
 
         parser.add_argument('--yes-location', action='store_true', dest='yes_location',
-                            default=False, help="Do write '#: filename:line' lines.")
+                            default=settings.ADD_LOCATION if hasattr(settings,'ADD_LOCATION') else False, 
+                            help="Do write '#: filename:line' lines.")
         parser.add_argument('--yes-wrap', action='store_true', dest='yes_wrap',
-                            default=False, help="Do wrap long messages for 80 chars")
+                            default=settings.DO_WRAP if hasattr(settings, 'DO_WRAP') else False, 
+                            help="Do wrap long messages for 80 chars")
         parser.add_argument('apps', nargs='*', choices=settings.INSTALLED_APPS + [[],])
 
     def handle(self, *args, **options):


### PR DESCRIPTION
This PR is a fix for issue #1 

### Unit tests

When `ADD_LOCATION` is set to `True` in the `settings.py`

```
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-03-11 03:14+0000\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n != 1);\n"

#: remmon/settings.py:113
msgid "English"
msgstr ""

#: remmon/settings.py:114
msgid "Catalan"
msgstr ""

#: remmon/settings.py:115
msgid "Tetun"
msgstr ""

#: remmon/settings.py:116
msgid "Marathi"
msgstr ""

#: static/ng_templates/list_servers.html:8
msgid "Enrolled Servers"
msgstr ""

#: templates/home.html:32
msgid "Welcome to Catalpa!"
msgstr ""
```

When `ADD_LOCATION` is set to `False` or absent in the `settings.py`

```
# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-03-11 03:31+0000\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n != 1);\n"

msgid "English"
msgstr ""

msgid "Catalan"
msgstr ""

msgid "Tetun"
msgstr ""

msgid "Marathi"
msgstr ""

msgid "Enrolled Servers"
msgstr ""

msgid "Welcome to Catalpa!"
msgstr ""
```

When `DO_WRAP` is set to `False` or absent in the `settings.py`

```
# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-03-11 03:41+0000\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n != 1);\n"
#. Translators: This message is a test of wrap line
msgid "This is a big line to test the wrap by setting DO_WRAP in settings.py. Do let me know if it works."
msgstr ""

```

When `DO_WRAP` is set to `True` in `setting.py`

```
# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-03-11 03:46+0000\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n != 1);\n"

#. Translators: This message is a test of wrap line
msgid ""
"This is a big line to test the wrap by setting DO_WRAP in settings.py. Do "
"let me know if it works."
msgstr ""

```