### PR TITLE
Making --no-obsolete configurable

### DIFF
--- a/management/commands/makemessages.py
+++ b/management/commands/makemessages.py
@@ -20,12 +20,16 @@ class Command(BaseMakemessages):
                             default=False, help="Do write '#: filename:line' lines.")
         parser.add_argument('--yes-wrap', action='store_true', dest='yes_wrap',
                             default=False, help="Do wrap long messages for 80 chars")
+        parser.add_argument('--yes-obsolete', action='store_true', dest='yes_obsolete',
+                            default=getattr(settings, 'KEEP_OBSOLETE', False), 
+                            help="Keep obsolete messages.")
         parser.add_argument('apps', nargs='*', choices=settings.INSTALLED_APPS + [[],])
 
     def handle(self, *args, **options):
         self.stdout.write("running the MakeMessagesPlus command - see help for details\n")
         options['no_location'] = not options.get('yes_location')
         options['no_wrap'] = not options.get('yes_wrap')
+        options['no_obsolete'] = not options.get('yes_obsolete')
 
         if len(options['apps']):
             for app in options['apps']:


### PR DESCRIPTION
I observed following.  

`python manage.py makemessages -l <locale>`  

If there is no `gettext` in the file being processed, the above command won't `write/update` `.po` file. That means if the corresponding `.po` file earlier had entries for `msgstr` and `msgid`, then it won't remove those entries unless file being processed had at least one `gettext`. 

> Note: Above behavior is irrespective of `--no-obsolete`      
  
  
  
  
  
**Now to make the `--no-obsolete` work as expected we need to follow the steps below.**

1.  First thing run `python manage.py makemessages -l <locale>`, this would write `.po` file with `msgid` and `msgstr`.   

2.  Now set `msgstr` and run `python manage.py compilemessages -l <locale>`. This command writes `.mo` file in the same directory as `.po` file. 

3.   Now next time when you run `makemessages` again (**without --no-obsolete**), `.po` and `.mo` files are compared and missing/deleted `gettext` are commented in `.po` file.  
4.   And when you run `makemessages --no-obsolete`, commented entries are removed from the `.po` file.  



`E.g`  

if you have 3 `gettext` entries, and you run `makemessages` first time, it would write 3 `msgid` and 3 `msgstr` in `.po` file. Now if you remove all `gettext` entries, `.po` file won't be updated after you run `makemessages` again, but if your keep at least 1 `gettext` entry in same file and  run `makemessages` again, it would delete all `msgid` and `msgstr` for deleted `gettext` entries.   

But if you run `compilemessages` after  `makemessages`, `.mo` file is created and then for subsequent `makemessages` commands `.po` and `.mo` files are compared and then `msgid` and `msgstr` is commented in `.po` file for deleted `gettext` entries.

Then finally when you run `makemessages` with `--no-obsolete` option the commented messages from `.po` files are deleted permanently.




**Unit Tests** 

When `KEEP_OBSOLETE` in settings.py is `True`
```

# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-03-21 15:27+0000\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n > 1);\n"

#. Translators: This message is a test of wrap line
#: servers/views.py:31
msgid "Do let me know if it works."
msgstr "Avisa'm si funciona."

#~ msgid "This is another gettext"
#~ msgstr "Aquest és un altre gettext" 
```


When `KEEP_OBSOLETE` in settings.py is `False`
```

# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2018-03-21 15:27+0000\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n > 1);\n"

#. Translators: This message is a test of wrap line
#: servers/views.py:31
msgid "Do let me know if it works."
msgstr "Avisa'm si funciona."
```